### PR TITLE
change gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore paths that contain user-generated content.
-web/sites/*/files
+
 web/sites/*/private
 
 # Ignore Lando override files


### PR DESCRIPTION
Removing reference to the files directory from the .gitignore so that we can easily copy files via git to sites on pantheon.