### PR TITLE
set form fields to hidden in cu_forms_bundle module

### DIFF
--- a/web/profiles/express/modules/custom/cu_forms_bundle/cu_forms_bundle.module
+++ b/web/profiles/express/modules/custom/cu_forms_bundle/cu_forms_bundle.module
@@ -307,6 +307,9 @@ function cu_forms_bundle_form_webform_component_edit_form_alter(&$form, &$form_s
     'png' => 'png'
   );
   $form['validation']['extensions']['addextensions']['#default_value'] = '';
+
+  $form['extra']['scheme']['#type'] = 'hidden';
+  $form['extra']['directory']['#type'] = 'hidden';
 }
 
 /**


### PR DESCRIPTION
closes #15 

the contrib webform model has its own definition of a file upload field type for forms. I just found a hook in cu_forms_bundle and used it to make the upload directory and scheme fields hidden so users do not accidentally set them to the public upload directory.