### PR TITLE
Add Mainstay Chat JS Include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ web/sites/*/private
 # Ignore IDE workspace files
 .idea
 .vscode
+web/.htaccess

--- a/web/profiles/express/modules/custom/cu_js_includes/README.md
+++ b/web/profiles/express/modules/custom/cu_js_includes/README.md
@@ -16,7 +16,7 @@
     - put the include name in the `$types` array found on line 28 of `cu_js_includes.context.inc` instead
 4. Create a form function `cu_js_includes_<yourIncludeName>_form()` in `includes/cu_js_includes.forms.inc`:
     - take the other form functions as guides and make whatever adjustments needed.
-5. Add you include to the `includes/cu_js_includes.permissions.inc` to the `cu_js_includes_secure_permissions()` function:
+5. Add your include to the `includes/cu_js_includes.permissions.inc` to the `cu_js_includes_secure_permissions()` function:
     - Again, follow the pattern established there.
 6. Add your js include to the `$custom_types` array inside `cu_js_includes_get_include_types()` found in the `cu_js_includes.types.inc` file:
     - Look previous includes for guidance

--- a/web/profiles/express/modules/custom/cu_js_includes/README.md
+++ b/web/profiles/express/modules/custom/cu_js_includes/README.md
@@ -6,16 +6,16 @@
 
 ## Add a JavaScript Include to Drupal 7 Web Express
 1. Add line to .install file for including it in the variable database table.
-    - go to `function cu_js_install()` on L81.
-    - inside th `$types` array definition add your javascript include following the pattern of the others found there.
+    - go to `function cu_js_includes_install()` on L81.
+    - inside the `$types` array definition add your javascript include following the pattern of the others found there.
 2. If your js include defines a block to be placed using the block/region layout tools:
-    - add its name to the `$type = array('statuspage', 'slateform');` array definition in cu_js_includes.module file, in the cu_js_includes_block_options() function.
+    - add its name to the `$type = array('statuspage', 'slateform');` array definition in `cu_js_includes.module` file, in the `cu_js_includes_block_options()` function.
     - You can probably skip step 3.
 3. If your js include defines a block to be placed via a context reaction:
     - You will probably skip step 2.
-    - put the include name in the $types array found on line 28 of cu_js_includes.context.inc instead
+    - put the include name in the `$types` array found on line 28 of `cu_js_includes.context.inc` instead
 4. Create a form function `cu_js_includes_<yourIncludeName>_form()` in `includes/cu_js_includes.forms.inc`:
-    - take the other form functions guides and make whatever adjustments needed.
+    - take the other form functions as guides and make whatever adjustments needed.
 5. Add you include to the `includes/cu_js_includes.permissions.inc` to the `cu_js_includes_secure_permissions()` function:
     - Again, follow the pattern established there.
 6. Add your js include to the `$custom_types` array inside `cu_js_includes_get_include_types()` found in the `cu_js_includes.types.inc` file:

--- a/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.install
+++ b/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.install
@@ -98,3 +98,20 @@ function cu_js_includes_install() {
 function cu_js_includes_update_7001() {
   secure_permissions_rebuild();
 }
+
+
+/**
+ * Add Mainstay include.
+ */
+function cu_js_includes_update_7002() {
+  $types = array(
+    'admithub' => 'admithub',
+    'livechat' => 'livechat',
+    'slateform' => 'slateform',
+    'statuspage' => 'statuspage',
+    'mainstay' => 'mainstay'
+  );
+  variable_set('cu_js_includes_enabled', $types);
+  // Menu items are already added so we need to rebuild if types are changed.
+  menu_rebuild();
+}

--- a/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.install
+++ b/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.install
@@ -83,7 +83,8 @@ function cu_js_includes_install() {
     'admithub' => 'admithub',
     'livechat' => 'livechat',
     'slateform' => 'slateform',
-    'statuspage' => 'statuspage'
+    'statuspage' => 'statuspage',
+    'mainstay' => 'mainstay'
   );
   variable_set('cu_js_includes_enabled', $types);
   // Menu items are already added so we need to rebuild if types are changed.

--- a/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.module
+++ b/web/profiles/express/modules/custom/cu_js_includes/cu_js_includes.module
@@ -385,6 +385,9 @@ function cu_js_includes_preprocess_html(&$vars) {
           elseif ($match->type == 'admithub') {
             $vars['page']['page_bottom']['admithub']['#markup'] = $embed_code;
           }
+          elseif ($match->type == 'mainstay') {
+            $vars['page']['page_bottom']['mainstay']['#markup'] = $embed_code;
+          }
         }
       }
     }

--- a/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.context.inc
+++ b/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.context.inc
@@ -28,6 +28,7 @@ class context_reaction_js_include extends context_reaction {
     $types = array(
       'admithub',
       'livechat',
+      'mainstay'
     );
     // Types of filters that use this reaction that are also enabled.
     $filter = array_intersect($enabled_includes, $types);

--- a/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.forms.inc
+++ b/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.forms.inc
@@ -96,3 +96,32 @@ function cu_js_includes_slateform_form(&$form, &$form_state, $id = NULL, $data =
     '#size' => 128,
   );
 }
+
+/**
+ * Form values for mainstay form embed.
+ *
+ * @param array $form
+ *   Form containing default embed template form options.
+ * @param array $form_state
+ *   State of the default embed template form.
+ * @param int|null $id
+ *   ID of the current embed being edited if that embed exists.
+ * @param array $data
+ *   Data of the current embed if it is being edited.
+ */
+function cu_js_includes_mainstay_form(&$form, &$form_state, $id = NULL, $data = array()) {
+  $form['options']['account_id'] = array(
+    '#title' => t('License ID'),
+    '#type' => 'textfield',
+    '#default_value' => !empty($data['account_id']) ? $data['account_id'] : '',
+    '#required' => TRUE,
+    '#size' => 128,
+  );
+  $form['options']['college_id'] = array(
+    '#title' => t('College ID'),
+    '#type' => 'textfield',
+    '#default_value' => !empty($data['college_id']) ? $data['CuBoulder'] : 'CuBoulder',
+    '#required' => TRUE,
+    '#size' => 128,
+  );
+}

--- a/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.permissions.inc
+++ b/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.permissions.inc
@@ -17,6 +17,7 @@ function cu_js_includes_secure_permissions($role) {
     'anonymous user' => array(
       'view js includes',
       'view admithub js includes',
+      'view mainstay js includes',
       'view livechat js includes',
       'view statuspage js includes',
       'view slateform js includes',
@@ -25,6 +26,7 @@ function cu_js_includes_secure_permissions($role) {
     'authenticated user' => array(
       'view js includes',
       'view admithub js includes',
+      'view mainstay js includes',
       'view livechat js includes',
       'view statuspage js includes',
       'view slateform js includes',

--- a/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.types.inc
+++ b/web/profiles/express/modules/custom/cu_js_includes/includes/cu_js_includes.types.inc
@@ -23,6 +23,14 @@ function cu_js_includes_get_include_types() {
     'template' => 'templates/admithub',
   );
 
+  $custom_types['mainstay'] = array(
+    'label' => 'Mainstay Chatbot',
+    'form_callback' => 'cu_js_includes_mainstay_form',
+    'renderer' => 'page_top_bottom',
+    'path' => $module_path,
+    'template' => 'templates/mainstay',
+  );
+
   $custom_types['livechat'] = array(
     'label' => 'LiveChat',
     'form_callback' => 'cu_js_includes_livechat_form',
@@ -58,6 +66,7 @@ function cu_js_includes_get_include_types() {
 function cu_js_includes_express_node_list_groups($bundles) {
   $bundles['includes']['title'] = 'Include Types';
   $bundles['includes']['types'][] = 'Add AdmitHub Include';
+  $bundles['includes']['types'][] = 'Add Mainstay Chatbot Include';
   $bundles['includes']['types'][] = 'Add LiveChat Include';
   $bundles['includes']['types'][] = 'Add Slate Form Include';
   $bundles['includes']['types'][] = 'Add StatusPage Include';

--- a/web/profiles/express/modules/custom/cu_js_includes/templates/mainstay.tpl.php
+++ b/web/profiles/express/modules/custom/cu_js_includes/templates/mainstay.tpl.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Template for Mainstat chatbot include.
+ */
+?>
+<script>
+    window.admitHubBot = {
+        botToken: "<?php print check_plain($account_id); ?>",
+        collegeId: "<?php print check_plain($college_id); ?>"
+    };
+</script>
+<script async src="https://webbot.mainstay.com/static/js/webchat.js"></script>
+<link rel="stylesheet" type="text/css" href="https://webbot.mainstay.com/static/css/webchat.css">


### PR DESCRIPTION
Admithub, a service some sites use for chatbots, has changed name/ownership and is now known as Mainstay as well as updated their chatbot code. I have made a new js_include in response to help scout ticket 