### PR TITLE
adding in code block to send site url when loading chat client

### DIFF
--- a/web/profiles/express/modules/custom/cu_js_includes/templates/servicecloud.tpl.php
+++ b/web/profiles/express/modules/custom/cu_js_includes/templates/servicecloud.tpl.php
@@ -146,7 +146,12 @@
         embedded_svc.settings.offlineSupportMinimizedText = 'Questions? Let\'s Chat'; //(Defaults to Contact Us)
         embedded_svc.settings.enabledFeatures = ['LiveAgent'];
         embedded_svc.settings.entryFeature = 'LiveAgent';
-
+        embedded_svc.settings.extraPrechatFormDetails = [{
+            "label":"Current Site",
+            "value":location.href,
+            "transcriptFields":[ "Current_Site__c" ],
+            "displayToAgent":true
+        }];
         embedded_svc.init(
 			'https://cu.my.salesforce.com',
 			'https://cu.my.salesforce-sites.com/BuffInfo',


### PR DESCRIPTION
Just adds a setting to the js in the <script> tag in the servicecloud.tpl.php file

The code is up on https://www.colorado.edu/ucbdev-sandbox-express if you want to test its functionality there before creating a release.

I have confirmed with the person who gave me the code snippet that they are receiving the expected data after testing it myself on the site given above.